### PR TITLE
Add variable nodes and lambda binding

### DIFF
--- a/diagram_tests.ipynb
+++ b/diagram_tests.ipynb
@@ -597,8 +597,19 @@
     "dia = app(neg, id1, id2, value=\"False\")\n",
     "dia.render()"
    ]
-  }
- ],
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "lambda_test",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lam_node = lam(\"x\", app(pred(\"Q\", 2), var(\"x\"), var(\"x\")))\n",
+    "lam_node.render()\n"
+  ]
+ }
+],
  "metadata": {
   "kernelspec": {
    "display_name": "Python 3",


### PR DESCRIPTION
## Summary
- track free variables in Diagram
- add `var()` constructor
- connect lambda ports to bound variables
- show lambda with repeated variable in tests

## Testing
- `pip install graphviz >/tmp/pip.log && tail -n 20 /tmp/pip.log`
- `python3 - <<'PY'
from symbolize.relation.diagram import id, pred, op, app, lam, var
lam_d = lam('x', app(pred('Q',2), var('x'), var('x')))
print(bool(lam_d.free_vars))
print('dotted' in lam_d.full_dot())
PY`

------
https://chatgpt.com/codex/tasks/task_e_6876893d50a08320a597397d587f49b2